### PR TITLE
fix min update break chapter issue

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/com/tscsoft/naroureader/NovelHtmlObject.java
+++ b/app/src/main/java/com/tscsoft/naroureader/NovelHtmlObject.java
@@ -1,0 +1,14 @@
+package com.tscsoft.naroureader;
+
+public class NovelHtmlObject {
+    public static class EpisodeFetcher {
+        private int mChapter;
+        public String getChapter() {
+            return "";
+        }
+
+        public void setChapter(int i) {
+            this.mChapter = i;
+        }
+    }
+}

--- a/app/src/main/java/com/tscsoft/naroureader/beans/ListBean.java
+++ b/app/src/main/java/com/tscsoft/naroureader/beans/ListBean.java
@@ -2,9 +2,17 @@ package com.tscsoft.naroureader.beans;
 
 import com.tscsoft.naroureader.services.ServiceItem;
 public abstract class ListBean {
+
+    public abstract int getReadStartNo();
+    public abstract void setReadStartNo(int i);
     public abstract boolean isShort();
     public abstract int getAllNo();
     public abstract String getUrl();
     public abstract ServiceItem.WorkMode getWorkMode();
     public abstract int getPrevAllNo();
+
+    public abstract int getUpdateStartNo();
+    public abstract void setUpdateStartNo(int i);
+
+    public abstract String getNcode();
 }

--- a/app/src/main/java/com/tscsoft/naroureader/beans/NovelBean.java
+++ b/app/src/main/java/com/tscsoft/naroureader/beans/NovelBean.java
@@ -1,0 +1,9 @@
+package com.tscsoft.naroureader.beans;
+
+public class NovelBean {
+    public int getChapter() {
+        return 0;
+    }
+
+    public static class Accessor {}
+}

--- a/app/src/main/java/com/tscsoft/naroureader/utils/Modding.java
+++ b/app/src/main/java/com/tscsoft/naroureader/utils/Modding.java
@@ -16,8 +16,22 @@ import org.jsoup.nodes.Element;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Modding {
+    public static final Pattern PATTERN_PAGE_LINK = Pattern.compile("/n\\d{4}[a-z]+/(\\d+?)/");
+
+    private static int getUpdateStartNo(Document doc) {
+        Element firstLink = doc.selectFirst(".index_box .subtitle a[href]");
+        if (firstLink == null) return 0;
+        String firstLinkHref = firstLink.attr("href");
+        Matcher matcher = PATTERN_PAGE_LINK.matcher(firstLinkHref);
+        if (!matcher.find()) return 0;
+        String firstLinkNo = matcher.group(1);
+        if (firstLinkNo == null) return 0;
+        return Integer.parseInt(firstLinkNo);
+    }
     public static String patchNovelHtml(String baseHtml, HttpGet httpGet, ListBean listBean) throws IOException, InterruptedException {
         Log.d("NarouModding", "patchNovelHtml()");
         Log.d("NarouModding", "listBean: " + listBean);
@@ -38,6 +52,9 @@ public class Modding {
             Log.d("NarouModding", "Load start from: " + url);
             String html = httpGet.get(url.toExternalForm());
             baseDoc = Jsoup.parse(html);
+            int updateStartNo = getUpdateStartNo(baseDoc);
+            listBean.setUpdateStartNo(updateStartNo);
+            Log.d("NarouModding", "updateStartNo: " + updateStartNo);
         }
 
         Element nextPager = baseDoc.selectFirst("a.novelview_pager-next[href]");

--- a/app/src/main/java/com/tscsoft/naroureader/utils/ReverseDebug.java
+++ b/app/src/main/java/com/tscsoft/naroureader/utils/ReverseDebug.java
@@ -1,0 +1,60 @@
+package com.tscsoft.naroureader.utils;
+
+import android.util.Log;
+
+public class ReverseDebug {
+
+    public static class ReverseDebugTrace extends Exception {
+    }
+
+    private static final String TAG = "ReverseDebug";
+
+    public static void trace() {
+        new ReverseDebugTrace().printStackTrace();
+    }
+    public static void d(String msg) {
+        Log.d(TAG, msg);
+    }
+
+    public static void d(Object msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void d(int msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void d(long msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void d(float msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void d(double msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void d(char msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void d(boolean msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void d(byte msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void d(short msg) {
+        d(String.valueOf(msg));
+    }
+
+    public static void test() {
+        d("TEST");
+        d(Integer.valueOf(123));
+        trace();
+    }
+}

--- a/app/src/main/java/com/tscsoft/naroureader/utils/UpdateManager.java
+++ b/app/src/main/java/com/tscsoft/naroureader/utils/UpdateManager.java
@@ -1,0 +1,22 @@
+package com.tscsoft.naroureader.utils;
+
+import com.tscsoft.naroureader.beans.ListBean;
+import com.tscsoft.naroureader.beans.NovelBean;
+import com.tscsoft.naroureader.NovelHtmlObject;
+
+public class UpdateManager {
+    private NovelBean.Accessor mEpisodeAccessor;
+
+    private boolean loadEpisode(String str, int i, NovelBean novelBean, NovelBean.Accessor accessor) {
+        return false;
+    }
+
+    private void modEpisodeFetcherChapter(ListBean listBean, NovelHtmlObject.EpisodeFetcher episodeFetcher) {
+        int i = listBean.getUpdateStartNo() - 1;
+        if (i < 1) return;
+        NovelBean novelBean = new NovelBean();
+        loadEpisode(listBean.getNcode(), i, novelBean, this.mEpisodeAccessor);
+        int lastChapter = novelBean.getChapter();
+        episodeFetcher.setChapter(lastChapter);
+    }
+}


### PR DESCRIPTION
## Overview
低負荷更新で目次の章が破損する問題を修正する試み
https://github.com/kairi003/NarouReaderMod/issues/1

- `com.tscsoft.naroureader.utils.ReverseDubug` はデバッグ用クラス 
- パッチに利用されるコードが含まれるクラスは以下 
    - `com.tscsoft.naroureader.utils.Modding` 
    - `com.tscsoft.naroureader.utils.UpdateManager `

## smali編集で追加すること
- `UpdateManager` のメソッド挿入
- `ListBean` クラスに `int updateStartNo`フィールドとsetter/getter追加
- `EpisodeFecher.mChapter` のsetter `void setChapter(int i)` を追加